### PR TITLE
✅ Add tests for Correlation state changes

### DIFF
--- a/_integration_tests/test/correlations/get_all_correlations.js
+++ b/_integration_tests/test/correlations/get_all_correlations.js
@@ -87,7 +87,7 @@ describe('Management API:   GET  ->  /correlations/all', () => {
       * Give the persistance backend some time to persist the Correlation
       * results.
       */
-      await wait(500);
+      await wait(750);
     }
 
     const correlations = await testFixtureProvider

--- a/_integration_tests/test/correlations/get_all_correlations.js
+++ b/_integration_tests/test/correlations/get_all_correlations.js
@@ -11,17 +11,17 @@ describe('Management API:   GET  ->  /correlations/all', () => {
 
   let testFixtureProvider;
 
-  const processModelId = 'generic_sample';
+  const genericProcessModelId = 'generic_sample';
   const errorProcessModelId = 'test_management_api_correlation_error';
 
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    await testFixtureProvider.importProcessFiles([processModelId, errorProcessModelId]);
+    await testFixtureProvider.importProcessFiles([genericProcessModelId, errorProcessModelId]);
 
-    await createFinishedProcessInstance(testFixtureProvider.identities.defaultUser, processModelId);
-    await createFinishedProcessInstance(testFixtureProvider.identities.secondDefaultUser, processModelId);
+    await createFinishedProcessInstance(testFixtureProvider.identities.defaultUser, genericProcessModelId);
+    await createFinishedProcessInstance(testFixtureProvider.identities.secondDefaultUser, genericProcessModelId);
   });
 
   after(async () => {
@@ -40,7 +40,7 @@ describe('Management API:   GET  ->  /correlations/all', () => {
 
     const result = await testFixtureProvider
       .managementApiClientService
-      .startProcessInstance(identity, processModelIdToUse, startEventId, payload, returnOn);
+      .startProcessInstance(identity, processModelIdToUse, processModelIdToUse, payload, returnOn);
 
     should(result).have.property('correlationId');
     should(result.correlationId).be.equal(payload.correlationId);
@@ -48,7 +48,7 @@ describe('Management API:   GET  ->  /correlations/all', () => {
     return result.correlationId;
   }
 
-  it('should return all correlations for an user through the management api', async () => {
+  it('should include all correlations that were finished with an error', async () => {
 
     const correlations = await testFixtureProvider
       .managementApiClientService

--- a/_integration_tests/test/correlations/get_all_correlations.js
+++ b/_integration_tests/test/correlations/get_all_correlations.js
@@ -40,7 +40,7 @@ describe('Management API:   GET  ->  /correlations/all', () => {
 
     const result = await testFixtureProvider
       .managementApiClientService
-      .startProcessInstance(identity, processModelIdToUse, processModelIdToUse, payload, returnOn);
+      .startProcessInstance(identity, processModelIdToUse, startEventId, payload, returnOn);
 
     should(result).have.property('correlationId');
     should(result.correlationId).be.equal(payload.correlationId);


### PR DESCRIPTION
**Changes:**

1. Adds a Test which checks, if a Correlations, which contains a ProcessModel that lead to an Error during its execution, the `error` state is correctly set and retrieved.


**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/229

PR: #33
## How can others test the changes?

> Describe how others can test your changes (you can remove this section for typo fixes etc.)

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).