### PR TITLE
🔥Remove consumer api 

### DIFF
--- a/_integration_tests/bpmn/generic_deployment_sanity_check.bpmn
+++ b/_integration_tests/bpmn/generic_deployment_sanity_check.bpmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
+  <bpmn:collaboration id="Collaboration_1cidyxu">
+    <bpmn:participant id="Participant_0px403d" name="generic_deployment_sanity_check" processRef="generic_deployment_sanity_check" />
+  </bpmn:collaboration>
+  <bpmn:process id="generic_deployment_sanity_check" name="generic_deployment_sanity_check" isExecutable="true">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Default_Test_Lane">
+        <bpmn:extensionElements>
+          <camunda:properties>
+            <camunda:property name="role" value="user" />
+          </camunda:properties>
+        </bpmn:extensionElements>
+        <bpmn:flowNodeRef>scriptTask_CreateSampleResult</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_Success</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_666</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:sequenceFlow id="SequenceFlow_0vspoh6" sourceRef="StartEvent_666" targetRef="scriptTask_CreateSampleResult" />
+    <bpmn:sequenceFlow id="SequenceFlow_0dqpbny" name="" sourceRef="scriptTask_CreateSampleResult" targetRef="EndEvent_Success" />
+    <bpmn:scriptTask id="scriptTask_CreateSampleResult" name="Sample output">
+      <bpmn:incoming>SequenceFlow_0vspoh6</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0dqpbny</bpmn:outgoing>
+      <bpmn:script>return 'hello'</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="EndEvent_Success" name="Finish">
+      <bpmn:incoming>SequenceFlow_0dqpbny</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_666" name="Start Event 1">
+      <bpmn:outgoing>SequenceFlow_0vspoh6</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="481" height="227" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_666">
+        <dc:Bounds x="99" y="98" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="87" y="134" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="451" height="227" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0vspoh6_di" bpmnElement="SequenceFlow_0vspoh6">
+        <di:waypoint x="135" y="116" />
+        <di:waypoint x="184" y="116" />
+        <di:waypoint x="184" y="116" />
+        <di:waypoint x="231" y="116" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="154" y="109.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_183p48e_di" bpmnElement="scriptTask_CreateSampleResult">
+        <dc:Bounds x="231" y="76" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0by117k_di" bpmnElement="EndEvent_Success">
+        <dc:Bounds x="405" y="98" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="408" y="137" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dqpbny_di" bpmnElement="SequenceFlow_0dqpbny">
+        <di:waypoint x="331" y="116" />
+        <di:waypoint x="368" y="116" />
+        <di:waypoint x="368" y="116" />
+        <di:waypoint x="405" y="116" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="338" y="109.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/bpmn/generic_deployment_sanity_check_updated.bpmn
+++ b/_integration_tests/bpmn/generic_deployment_sanity_check_updated.bpmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
+  <bpmn:collaboration id="Collaboration_1cidyxu">
+    <bpmn:participant id="Participant_0px403d" name="generic_deployment_sanity_check" processRef="generic_deployment_sanity_check" />
+  </bpmn:collaboration>
+  <bpmn:process id="generic_deployment_sanity_check" name="generic_deployment_sanity_check" isExecutable="true">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Default_Test_Lane">
+        <bpmn:extensionElements>
+          <camunda:properties>
+            <camunda:property name="role" value="user" />
+          </camunda:properties>
+        </bpmn:extensionElements>
+        <bpmn:flowNodeRef>scriptTask_CreateSampleResult</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_Success</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_666</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:sequenceFlow id="SequenceFlow_0vspoh6" sourceRef="StartEvent_666" targetRef="scriptTask_CreateSampleResult" />
+    <bpmn:sequenceFlow id="SequenceFlow_0dqpbny" name="" sourceRef="scriptTask_CreateSampleResult" targetRef="EndEvent_Success" />
+    <bpmn:scriptTask id="scriptTask_CreateSampleResult" name="Sample output">
+      <bpmn:incoming>SequenceFlow_0vspoh6</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0dqpbny</bpmn:outgoing>
+      <bpmn:script>return 'hello'</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="EndEvent_Success" name="Finish">
+      <bpmn:incoming>SequenceFlow_0dqpbny</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_666" name="Start Event 1">
+      <bpmn:outgoing>SequenceFlow_0vspoh6</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="481" height="227" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_666">
+        <dc:Bounds x="99" y="98" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="87" y="134" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="451" height="227" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0vspoh6_di" bpmnElement="SequenceFlow_0vspoh6">
+        <di:waypoint x="135" y="116" />
+        <di:waypoint x="184" y="116" />
+        <di:waypoint x="184" y="116" />
+        <di:waypoint x="231" y="116" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="154" y="109.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_183p48e_di" bpmnElement="scriptTask_CreateSampleResult">
+        <dc:Bounds x="231" y="76" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0by117k_di" bpmnElement="EndEvent_Success">
+        <dc:Bounds x="405" y="98" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="408" y="137" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dqpbny_di" bpmnElement="SequenceFlow_0dqpbny">
+        <di:waypoint x="331" y="116" />
+        <di:waypoint x="368" y="116" />
+        <di:waypoint x="368" y="116" />
+        <di:waypoint x="405" y="116" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="338" y="109.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/bpmn/process_model_name_mismatch.bpmn
+++ b/_integration_tests/bpmn/process_model_name_mismatch.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_15mlx3e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
+  <bpmn:collaboration id="Collaboration_0bxb8mu">
+    <bpmn:participant id="Participant_0ylnmok" name="process_model_name_mismatch_part_2" processRef="process_model_name_mismatch_part_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_model_name_mismatch_part_2" name="process_model_name_mismatch_part_2" isExecutable="true" camunda:versionTag="1.0">
+    <bpmn:laneSet id="LaneSet_08i1la7" />
+    <bpmn:startEvent id="startEvent" name="Start" camunda:formKey="TradeId">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="FormField_0go8uv1" label="test" type="long" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_0coq1aw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0coq1aw" sourceRef="startEvent" targetRef="Task_1a5ko2x" />
+    <bpmn:endEvent id="EndEvent_1fffh59" name="End">
+      <bpmn:incoming>SequenceFlow_0dlf4pr</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0dlf4pr" sourceRef="Task_1a5ko2x" targetRef="EndEvent_1fffh59" />
+    <bpmn:scriptTask id="Task_1a5ko2x" name="Do stuff">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0coq1aw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0dlf4pr</bpmn:outgoing>
+      <bpmn:script>return 'I am a Wookie!';</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0bxb8mu">
+      <bpmndi:BPMNShape id="Participant_0ylnmok_di" bpmnElement="Participant_0ylnmok">
+        <dc:Bounds x="109" y="69" width="517" height="195" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_10ithzc_di" bpmnElement="startEvent">
+        <dc:Bounds x="161" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="167" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1fffh59_di" bpmnElement="EndEvent_1fffh59">
+        <dc:Bounds x="548" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="556" y="167" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0coq1aw_di" bpmnElement="SequenceFlow_0coq1aw">
+        <di:waypoint x="197" y="142" />
+        <di:waypoint x="283" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dlf4pr_di" bpmnElement="SequenceFlow_0dlf4pr">
+        <di:waypoint x="383" y="142" />
+        <di:waypoint x="548" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_1iodeif_di" bpmnElement="Task_1a5ko2x">
+        <dc:Bounds x="283" y="102" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/bpmn/process_model_too_many_processes.bpmn
+++ b/_integration_tests/bpmn/process_model_too_many_processes.bpmn
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_15mlx3e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
+  <bpmn:collaboration id="Collaboration_0bxb8mu">
+    <bpmn:participant id="Participant_0ylnmok" name="process_model_too_many_processes" processRef="process_model_too_many_processes" />
+    <bpmn:participant id="Participant_1cr6h77" name="hello_hello" processRef="Process_0tfbmod" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_model_too_many_processes" name="process_model_too_many_processes" isExecutable="true" camunda:versionTag="1.0">
+    <bpmn:laneSet id="LaneSet_08i1la7" />
+    <bpmn:startEvent id="startEvent" name="Start" camunda:formKey="TradeId">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="FormField_0go8uv1" label="test" type="long" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_0coq1aw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0coq1aw" sourceRef="startEvent" targetRef="Task_1a5ko2x" />
+    <bpmn:sequenceFlow id="SequenceFlow_0eaztre" sourceRef="Task_1a5ko2x" targetRef="EndEvent_1fffh59" />
+    <bpmn:endEvent id="EndEvent_1fffh59" name="End">
+      <bpmn:incoming>SequenceFlow_0eaztre</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:scriptTask id="Task_1a5ko2x" name="Do stuff">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0coq1aw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0eaztre</bpmn:outgoing>
+      <bpmn:script>return 'hello hello';</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmn:process id="Process_0tfbmod" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_04wcb4s" name="Start 2">
+      <bpmn:outgoing>SequenceFlow_1b04ayn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1b04ayn" sourceRef="StartEvent_04wcb4s" targetRef="Task_1om4n2x" />
+    <bpmn:endEvent id="EndEvent_1626zcb" name="End 2">
+      <bpmn:incoming>SequenceFlow_0hbnkei</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hbnkei" sourceRef="Task_1om4n2x" targetRef="EndEvent_1626zcb" />
+    <bpmn:scriptTask id="Task_1om4n2x" name="Do other stuff">
+      <bpmn:incoming>SequenceFlow_1b04ayn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hbnkei</bpmn:outgoing>
+      <bpmn:script>return '';</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0bxb8mu">
+      <bpmndi:BPMNShape id="Participant_0ylnmok_di" bpmnElement="Participant_0ylnmok">
+        <dc:Bounds x="109" y="69" width="542" height="220" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_10ithzc_di" bpmnElement="startEvent">
+        <dc:Bounds x="161" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="167" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1fffh59_di" bpmnElement="EndEvent_1fffh59">
+        <dc:Bounds x="490" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="498" y="167" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0coq1aw_di" bpmnElement="SequenceFlow_0coq1aw">
+        <di:waypoint x="197" y="142" />
+        <di:waypoint x="283" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_1cr6h77_di" bpmnElement="Participant_1cr6h77">
+        <dc:Bounds x="109" y="347" width="540" height="197" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0eaztre_di" bpmnElement="SequenceFlow_0eaztre">
+        <di:waypoint x="383" y="142" />
+        <di:waypoint x="490" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0eicgk5_di" bpmnElement="Task_1a5ko2x">
+        <dc:Bounds x="283" y="102" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_04wcb4s_di" bpmnElement="StartEvent_04wcb4s">
+        <dc:Bounds x="165" y="439" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="167" y="482" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1b04ayn_di" bpmnElement="SequenceFlow_1b04ayn">
+        <di:waypoint x="201" y="457" />
+        <di:waypoint x="297" y="457" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1626zcb_di" bpmnElement="EndEvent_1626zcb">
+        <dc:Bounds x="525" y="439" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="529" y="482" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hbnkei_di" bpmnElement="SequenceFlow_0hbnkei">
+        <di:waypoint x="397" y="457" />
+        <di:waypoint x="525" y="457" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0ar8k7j_di" bpmnElement="Task_1om4n2x">
+        <dc:Bounds x="297" y="417" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/bpmn/process_model_without_lanes.bpmn
+++ b/_integration_tests/bpmn/process_model_without_lanes.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_15mlx3e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
+  <bpmn:collaboration id="Collaboration_0bxb8mu">
+    <bpmn:participant id="Participant_0ylnmok" name="process_model_without_lanes" processRef="process_model_without_lanes" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_model_without_lanes" name="process_model_without_lanes" isExecutable="true" camunda:versionTag="1.0">
+    <bpmn:laneSet id="LaneSet_08i1la7" />
+    <bpmn:startEvent id="StartEvent_NoLanes" name="Start" camunda:formKey="TradeId">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="FormField_0go8uv1" label="test" type="long" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_0coq1aw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0coq1aw" sourceRef="StartEvent_NoLanes" targetRef="Sample_ScriptTask" />
+    <bpmn:sequenceFlow id="SequenceFlow_0p9wvs1" sourceRef="Sample_ScriptTask" targetRef="EndEvent_NoLanes" />
+    <bpmn:endEvent id="EndEvent_NoLanes" name="End">
+      <bpmn:incoming>SequenceFlow_0p9wvs1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:scriptTask id="Sample_ScriptTask" name="Do stuff">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0coq1aw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0p9wvs1</bpmn:outgoing>
+      <bpmn:script>return 'hello world';</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0bxb8mu">
+      <bpmndi:BPMNShape id="Participant_0ylnmok_di" bpmnElement="Participant_0ylnmok">
+        <dc:Bounds x="109" y="69" width="469" height="186" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_10ithzc_di" bpmnElement="StartEvent_NoLanes">
+        <dc:Bounds x="161" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="167" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1fffh59_di" bpmnElement="EndEvent_NoLanes">
+        <dc:Bounds x="490" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="498" y="167" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0coq1aw_di" bpmnElement="SequenceFlow_0coq1aw">
+        <di:waypoint x="197" y="142" />
+        <di:waypoint x="283" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0p9wvs1_di" bpmnElement="SequenceFlow_0p9wvs1">
+        <di:waypoint x="383" y="142" />
+        <di:waypoint x="490" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_16oh0az_di" bpmnElement="Sample_ScriptTask">
+        <dc:Bounds x="283" y="102" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/index.js
+++ b/_integration_tests/index.js
@@ -19,7 +19,6 @@ const iocModuleNames = [
   '@essential-projects/services',
   '@essential-projects/sequelize_connection_manager',
   '@essential-projects/timing',
-  '@process-engine/consumer_api_core',
   '@process-engine/correlation.service',
   '@process-engine/correlations.repository.sequelize',
   '@process-engine/cronjob_history.service',

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -35,7 +35,6 @@
     "@essential-projects/http_extension": "~6.6.0",
     "@essential-projects/iam_contracts": "~3.5.0",
     "@essential-projects/timing": "~5.0.0",
-    "@process-engine/consumer_api_core": "6.0.0-ce0a8e55-b19",
     "@process-engine/correlation.service": "~1.3.0",
     "@process-engine/correlations.repository.sequelize": "~6.0.0",
     "@process-engine/cronjob_history.service": "~1.0.0",

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -51,7 +51,7 @@
     "@process-engine/logging.repository.file_system": "~1.3.0",
     "@process-engine/management_api_client": "6.0.0-694cc868-b20",
     "@process-engine/management_api_contracts": "12.0.0-543ede53-b22",
-    "@process-engine/management_api_core": "6.0.0-2bd28596-b24",
+    "@process-engine/management_api_core": "feature~remove_consumer_api",
     "@process-engine/management_api_http": "5.0.0-450a1201-b19",
     "@process-engine/metrics_api_core": "~2.0.0",
     "@process-engine/metrics.repository.file_system": "~2.0.0",

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -50,7 +50,7 @@
     "@process-engine/logging.repository.file_system": "~1.3.0",
     "@process-engine/management_api_client": "6.0.0-694cc868-b20",
     "@process-engine/management_api_contracts": "12.0.0-543ede53-b22",
-    "@process-engine/management_api_core": "feature~remove_consumer_api",
+    "@process-engine/management_api_core": "6.0.0-54a1f693-b25",
     "@process-engine/management_api_http": "5.0.0-450a1201-b19",
     "@process-engine/metrics_api_core": "~2.0.0",
     "@process-engine/metrics.repository.file_system": "~2.0.0",

--- a/_integration_tests/src/fixture_providers/setup_ioc_container.ts
+++ b/_integration_tests/src/fixture_providers/setup_ioc_container.ts
@@ -8,7 +8,6 @@ const iocModuleNames = [
   '@essential-projects/http_extension',
   '@essential-projects/sequelize_connection_manager',
   '@essential-projects/timing',
-  '@process-engine/consumer_api_core',
   '@process-engine/correlation.service',
   '@process-engine/correlations.repository.sequelize',
   '@process-engine/cronjob_history.service',

--- a/_integration_tests/test/process_models/delete_process_model.js
+++ b/_integration_tests/test/process_models/delete_process_model.js
@@ -35,6 +35,14 @@ describe('ManagementAPI:   GET  ->  /process_models/:process_model_id/delete', (
       .deleteProcessDefinitionsByProcessModelId(testFixtureProvider.identities.superAdmin, processModelId);
   });
 
+  it('should not throw an error when attempting to delete a non-existing ProcessModel', async () => {
+    const nonExistingProcessModelId = 'iwasneverhere';
+
+    await testFixtureProvider
+      .managementApiClient
+      .deleteProcessDefinitionsByProcessModelId(testFixtureProvider.identities.defaultUser, nonExistingProcessModelId);
+  });
+
   it('should fail to retrieve the ProcessModel, after its been deleted', async () => {
     try {
       const processModel = await testFixtureProvider

--- a/_integration_tests/test/process_models/update_process_definitions_by_name.js
+++ b/_integration_tests/test/process_models/update_process_definitions_by_name.js
@@ -4,21 +4,28 @@ const should = require('should');
 
 const TestFixtureProvider = require('../../dist/commonjs').TestFixtureProvider;
 
-// NOTE:
-// The deployment api alrady contains extensive testing for this, so there is no need to cover everything here.
-// We just need to ensure that all commands get passed correctly to the deployment api and leave the rest up to it.
 describe('Management API:   POST  ->  /process_models/:process_model_id/update', () => {
 
   let testFixtureProvider;
 
   const processModelId = 'generic_sample';
+  const processModelIdNoLanes = 'process_model_without_lanes';
+  const processModelIdNameMismatch = 'process_model_name_mismatch';
+  const processModelIdTooManyProcesses = 'process_model_too_many_processes';
+
   let processModelAsXml;
+  let processModelNoLanesAsXml;
+  let processModelPathNameMismatchAsXml;
+  let processModelPathTooManyProcessesAsXml;
 
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
     processModelAsXml = testFixtureProvider.readProcessModelFile(processModelId);
+    processModelNoLanesAsXml = testFixtureProvider.readProcessModelFile(processModelIdNoLanes);
+    processModelPathNameMismatchAsXml = testFixtureProvider.readProcessModelFile(processModelIdNameMismatch);
+    processModelPathTooManyProcessesAsXml = testFixtureProvider.readProcessModelFile(processModelIdTooManyProcesses);
   });
 
   after(async () => {
@@ -74,6 +81,19 @@ describe('Management API:   POST  ->  /process_models/:process_model_id/update',
     }
   });
 
+  it('should successfully import a ProcessModel without any lanes', async () => {
+
+    const importPayload = {
+      xml: processModelNoLanesAsXml,
+      overwriteExisting: true,
+    };
+
+    await testFixtureProvider
+      .managementApiClient
+      .updateProcessDefinitionsByName(testFixtureProvider.identities.defaultUser, processModelIdNoLanes, importPayload);
+    await assertThatImportWasSuccessful();
+  });
+
   it('should fail to deploy the ProcessModel, when the user is unauthorized', async () => {
 
     const importPayload = {
@@ -116,11 +136,55 @@ describe('Management API:   POST  ->  /process_models/:process_model_id/update',
     }
   });
 
+  // Note: Current restrictions state that a ProcessModel must have the same name as the Definition file.
+  // Otherwise the ProcessModel would not be retrievable.
+  it('should fail to import a ProcessModel, when the ProcessModel name does not match the ProcessDefinition name', async () => {
+
+    const importPayload = {
+      xml: processModelPathNameMismatchAsXml,
+      overwriteExisting: false,
+    };
+
+    try {
+      await testFixtureProvider
+        .managementApiClient
+        .updateProcessDefinitionsByName(testFixtureProvider.identities.defaultUser, processModelIdNameMismatch, importPayload);
+      should.fail(undefined, 'error', 'This request should have failed, because ProcessModel name differs from the ProcessDefinitions name!');
+    } catch (error) {
+      const expectedErrorMessage = /ProcessModel contained within the diagram.*?must also use the name/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
+    }
+  });
+
+  // Note: This may be supported in future versions, but right now such a BPMN file would break everything.
+  // So we need to make sure that those types of ProcessModels do not get deployed.
+  // Otherwise, BPMN Studio will be unable to use the Runtime at all.
+  it('should fail to import a ProcessModel, when the file contains more than one Process', async () => {
+
+    const importPayload = {
+      xml: processModelPathTooManyProcessesAsXml,
+      overwriteExisting: false,
+    };
+
+    try {
+      await testFixtureProvider
+        .managementApiClient
+        .updateProcessDefinitionsByName(testFixtureProvider.identities.defaultUser, processModelIdTooManyProcesses, importPayload);
+      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+    } catch (error) {
+      const expectedErrorMessage = /contains more than one ProcessModel/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
+    }
+  });
+
   async function assertThatImportWasSuccessful() {
 
-    const processModelService = await testFixtureProvider.resolveAsync('ProcessModelService');
-
-    const existingProcessModel = await processModelService
+    const existingProcessModel = await testFixtureProvider
+      .managementApiClient
       .getProcessModelById(testFixtureProvider.identities.defaultUser, processModelId);
 
     should.exist(existingProcessModel);

--- a/_integration_tests/test/process_models/update_sanity_checks.js
+++ b/_integration_tests/test/process_models/update_sanity_checks.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const should = require('should');
+
+const TestFixtureProvider = require('../../dist/commonjs').TestFixtureProvider;
+
+describe('Management API -> Sanity checks for ProcessModel update', () => {
+
+  let testFixtureProvider;
+
+  const processModelId = 'generic_deployment_sanity_check';
+  const processModelUpdatedId = 'generic_deployment_sanity_check_updated';
+
+  let processModelXml;
+  let processModelUpdatedXml;
+
+  before(async () => {
+
+    testFixtureProvider = new TestFixtureProvider();
+    await testFixtureProvider.initializeAndStart();
+
+    processModelXml = testFixtureProvider.readProcessModelFile(processModelId);
+    processModelUpdatedXml = testFixtureProvider.readProcessModelFile(processModelUpdatedId);
+
+    await performImport(processModelXml);
+    await performImport(processModelUpdatedXml);
+  });
+
+  after(async () => {
+    await testFixtureProvider.tearDown();
+  });
+
+  it('should always return the most up to date version of any ProcessModel', async () => {
+
+    const existingProcessModel = await testFixtureProvider
+      .managementApiClient
+      .getProcessModelById(testFixtureProvider.identities.defaultUser, processModelId);
+
+    should.exist(existingProcessModel);
+    should(existingProcessModel.id).be.equal(processModelId);
+
+    const startEvent = existingProcessModel.startEvents[0];
+
+    // The difference between the two process models is the ID of their StartEvent.
+    // We must be expecting the updated StartEvent ID.
+    const expectedStartEventId = 'StartEvent_666';
+
+    should.exist(startEvent);
+    should(startEvent.id).be.equal(expectedStartEventId, `Received an unexpected StartEventId: ${startEvent.id}`);
+  });
+
+  it('should not contain outdated versions of any ProcessModels, when querying all ProcessModels', async () => {
+
+    const processModels = await testFixtureProvider
+      .managementApiClient
+      .getProcessModels(testFixtureProvider.identities.defaultUser);
+
+    const occurencesOfTestProcessModel = processModels.processModels.filter((item) => {
+      return item.id === processModelId;
+    });
+
+    should(occurencesOfTestProcessModel.length).be.equal(1);
+  });
+
+  async function performImport(xml) {
+
+    const importPayload = {
+      xml: xml,
+      overwriteExisting: true,
+    };
+
+    await testFixtureProvider
+      .managementApiClient
+      .updateProcessDefinitionsByName(testFixtureProvider.identities.defaultUser, processModelId, importPayload);
+  }
+
+});


### PR DESCRIPTION
## Changes

1. Remove the ConsumerAPI from the test setup
2. The ManagementAPI no longer requires the ConsumerAPI for its work
3. Enhance the tests for ProcessModel deployment

## Issues

PR #56

## How to test the changes

Run the tests.