### PR TITLE
✅ Cleanup databases after each test run

### DIFF
--- a/_integration_tests/src/fixture_providers/test_fixture_provider.ts
+++ b/_integration_tests/src/fixture_providers/test_fixture_provider.ts
@@ -55,6 +55,8 @@ export class TestFixtureProvider {
   }
 
   public async tearDown(): Promise<void> {
+    await this.clearDatabases();
+
     const httpExtension = await this.container.resolveAsync<HttpExtension>('HttpExtension');
     await httpExtension.close();
     await this.bootstrapper.stop();
@@ -96,6 +98,16 @@ export class TestFixtureProvider {
     }
 
     return path.join(rootDirPath, bpmnDirectoryName);
+  }
+
+  public async clearDatabases(): Promise<void> {
+
+    const processModels = await this.processModelUseCases.getProcessModels(this.identities.superAdmin);
+
+    for (const processModel of processModels) {
+      logger.info(`Removing ProcessModel ${processModel.id} and all related data`);
+      await this.processModelUseCases.deleteProcessModel(this.identities.superAdmin, processModel.id);
+    }
   }
 
   private async initializeBootstrapper(): Promise<void> {

--- a/_integration_tests/test/correlations/get_active_correlations.js
+++ b/_integration_tests/test/correlations/get_active_correlations.js
@@ -13,9 +13,6 @@ describe('Management API:   GET  ->  /correlations/active', () => {
   let secondDefaultIdentity;
   const processModelId = 'usertask_sample';
 
-  let processInstance1Data;
-  let processInstance2Data;
-
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
@@ -27,13 +24,11 @@ describe('Management API:   GET  ->  /correlations/active', () => {
     defaultIdentity = testFixtureProvider.identities.defaultUser;
     secondDefaultIdentity = testFixtureProvider.identities.secondDefaultUser;
 
-    processInstance1Data = await createActiveCorrelations(defaultIdentity);
-    processInstance2Data = await createActiveCorrelations(secondDefaultIdentity);
+    await createActiveCorrelations(defaultIdentity);
+    await createActiveCorrelations(secondDefaultIdentity);
   });
 
   after(async () => {
-    await cleanup(processInstance1Data, defaultIdentity);
-    await cleanup(processInstance2Data, secondDefaultIdentity);
     await testFixtureProvider.tearDown();
   });
 
@@ -141,29 +136,6 @@ describe('Management API:   GET  ->  /correlations/active', () => {
     await processInstanceHandler.waitForProcessInstanceToReachSuspendedTask(result.correlationId, processModelId);
 
     return result;
-  }
-
-  async function cleanup(processInstanceData, identity) {
-
-    await new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(processInstanceData.processInstanceId, resolve);
-
-      const userTaskList = await testFixtureProvider
-        .managementApiClient
-        .getUserTasksForProcessModelInCorrelation(identity, processModelId, processInstanceData.correlationId);
-
-      const userTaskInput = {
-        formFields: {
-          Sample_Form_Field: 'Hello',
-        },
-      };
-
-      for (const userTask of userTaskList.userTasks) {
-        await testFixtureProvider
-          .managementApiClient
-          .finishUserTask(identity, userTask.processInstanceId, userTask.correlationId, userTask.flowNodeInstanceId, userTaskInput);
-      }
-    });
   }
 
 });

--- a/_integration_tests/test/cronjobs/get_active_cronjobs.js
+++ b/_integration_tests/test/cronjobs/get_active_cronjobs.js
@@ -28,7 +28,6 @@ describe('Management API:   GET  ->  /cronjobs/active', () => {
 
   after(async () => {
     await cronjobService.stop();
-    await disposeProcessModel(processModelId);
     await testFixtureProvider.tearDown();
   });
 
@@ -68,8 +67,6 @@ describe('Management API:   GET  ->  /cronjobs/active', () => {
 
   it('should not include cronjobs that are removed \'on the fly\'', async () => {
 
-    await disposeProcessModel(processModelId2);
-
     await cronjobService.remove(processModelId2);
 
     const cronjobs = await testFixtureProvider
@@ -100,11 +97,4 @@ describe('Management API:   GET  ->  /cronjobs/active', () => {
 
     return testFixtureProvider.processModelUseCases.getProcessModelById(testFixtureProvider.identities.defaultUser, processModelId);
   }
-
-  async function disposeProcessModel(processModelId) {
-    await testFixtureProvider
-      .processModelUseCases
-      .deleteProcessModel(testFixtureProvider.identities.defaultUser, processModelId);
-  }
-
 });

--- a/_integration_tests/test/events/get_events.js
+++ b/_integration_tests/test/events/get_events.js
@@ -35,7 +35,6 @@ describe('Management API:   Get waiting Events', () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -107,14 +106,4 @@ describe('Management API:   Get waiting Events', () => {
       should(event).have.property('eventName');
     });
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(processInstanceId, resolve);
-
-      await testFixtureProvider
-        .managementApiClient
-        .triggerSignalEvent(defaultIdentity, eventNameToTriggerAfterTest, {});
-    });
-  }
 });

--- a/_integration_tests/test/kpi/kpi_api_get_active_tokens.js
+++ b/_integration_tests/test/kpi/kpi_api_get_active_tokens.js
@@ -31,7 +31,6 @@ describe('Management API -> Get ActiveTokens - ', () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -168,26 +167,5 @@ describe('Management API -> Get ActiveTokens - ', () => {
     should(activeToken).have.property('processInstanceId');
     should(activeToken).have.property('flowNodeInstanceId');
     should(activeToken).have.property('createdAt');
-  }
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(processInstanceId, resolve);
-
-      const userTaskList = await testFixtureProvider
-        .managementApiClient
-        .getUserTasksForCorrelation(testFixtureProvider.identities.defaultUser, correlationId);
-
-      for (const userTask of userTaskList.userTasks) {
-        const userTaskProcessInstanceId = userTask.processInstanceId;
-        const userTaskInstanceId = userTask.flowNodeInstanceId;
-        const userTaskResult = {};
-
-        await testFixtureProvider
-          .managementApiClient
-          .finishUserTask(testFixtureProvider.identities.defaultUser, userTaskProcessInstanceId, correlationId, userTaskInstanceId, userTaskResult);
-      }
-    });
   }
 });


### PR DESCRIPTION
## Changes

This removes the need for having a (possibly messy) cleanup after each test.
Instead, the fixture provider will now mob up all test data, after each test is done.

This allows all the tests to run with a completely clean setup.

I also managed to nail down one nasty issue that caused the SQLite tests to fail seemingly at random (process-engine/process_engine_runtime#394).
Turns out, it wasn't so random after all.

## Issues

PR: #59

## How to test the changes

Run the tests.