### PR TITLE
♻️ Avoid unnecessary not found errors

### DIFF
--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -40,7 +40,7 @@
     "@process-engine/logging_api_core": "~2.0.0",
     "@process-engine/logging.repository.file_system": "~2.0.0",
     "@process-engine/management_api_client": "~6.2.0",
-    "@process-engine/management_api_core": "feature~avoid_unnecessary_not_found_errors",
+    "@process-engine/management_api_core": "6.4.0-alpha.1",
     "@process-engine/management_api_http": "~5.2.1",
     "@process-engine/process_engine_core": "~12.17.0",
     "@process-engine/persistence_api.repositories.sequelize": "~1.4.0",

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -40,7 +40,7 @@
     "@process-engine/logging_api_core": "~2.0.0",
     "@process-engine/logging.repository.file_system": "~2.0.0",
     "@process-engine/management_api_client": "~6.2.0",
-    "@process-engine/management_api_core": "~6.3.4",
+    "@process-engine/management_api_core": "feature~avoid_unnecessary_not_found_errors",
     "@process-engine/management_api_http": "~5.2.1",
     "@process-engine/process_engine_core": "~12.17.0",
     "@process-engine/persistence_api.repositories.sequelize": "~1.4.0",

--- a/_integration_tests/test/correlations/get_active_correlations.js
+++ b/_integration_tests/test/correlations/get_active_correlations.js
@@ -46,7 +46,7 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(defaultIdentity);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations.length).be.greaterThan(0);
 
       correlationList.correlations.forEach((correlation) => {
@@ -77,7 +77,7 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(testFixtureProvider.identities.superAdmin);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations.length).be.greaterThan(0);
 
       correlationList.correlations.forEach((correlation) => {
@@ -141,7 +141,7 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(defaultIdentity, 5);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(5);
     });
 
@@ -151,7 +151,7 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(defaultIdentity, 0, 2);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(2);
     });
 
@@ -161,7 +161,7 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(defaultIdentity, 5, 2);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(2);
     });
 
@@ -171,7 +171,7 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(defaultIdentity, 7, 5);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(3);
     });
 
@@ -181,7 +181,7 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(defaultIdentity, 0, 20);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(10);
 
     });
@@ -192,8 +192,8 @@ describe('ManagementAPI: GetActiveCorrelations', () => {
         .managementApiClient
         .getActiveCorrelations(defaultIdentity, 1000);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
-      should(correlationList.correlations).have.a.lengthOf(0);
+      should(correlationList.correlations).be.an.Array();
+      should(correlationList.correlations).be.empty();
     });
   });
 

--- a/_integration_tests/test/correlations/get_all_correlations.js
+++ b/_integration_tests/test/correlations/get_all_correlations.js
@@ -47,7 +47,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations.length).be.greaterThan(0);
 
       correlationList.correlations.forEach((correlation) => {
@@ -76,7 +76,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(testFixtureProvider.identities.superAdmin);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations.length).be.greaterThan(0);
 
       correlationList.correlations.forEach((correlation) => {
@@ -135,7 +135,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations.length).be.greaterThan(0);
 
       const oneCorrelationErrorState = correlationList.correlations.some((currentCorrelation) => {
@@ -164,7 +164,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity, 5);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(5);
     });
 
@@ -174,7 +174,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity, 0, 2);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(2);
     });
 
@@ -184,7 +184,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity, 5, 2);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(2);
     });
 
@@ -194,7 +194,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity, 7, 5);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(3);
     });
 
@@ -204,7 +204,7 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity, 0, 20);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(10);
 
     });
@@ -215,8 +215,8 @@ describe('ManagementAPI: GetAllCorrelations', () => {
         .managementApiClient
         .getAllCorrelations(defaultIdentity, 1000);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
-      should(correlationList.correlations).have.a.lengthOf(0);
+      should(correlationList.correlations).be.an.Array();
+      should(correlationList.correlations).be.empty();
     });
   });
 

--- a/_integration_tests/test/correlations/get_correlations_by_process_model_id.js
+++ b/_integration_tests/test/correlations/get_correlations_by_process_model_id.js
@@ -154,7 +154,7 @@ describe('ManagementAPI: GetCorrelationsByProcessModelId', () => {
         .managementApiClient
         .getCorrelationsByProcessModelId(defaultIdentity, processModelId, 5);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(5);
     });
 
@@ -164,7 +164,7 @@ describe('ManagementAPI: GetCorrelationsByProcessModelId', () => {
         .managementApiClient
         .getCorrelationsByProcessModelId(defaultIdentity, processModelId, 0, 2);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(2);
     });
 
@@ -174,7 +174,7 @@ describe('ManagementAPI: GetCorrelationsByProcessModelId', () => {
         .managementApiClient
         .getCorrelationsByProcessModelId(defaultIdentity, processModelId, 5, 2);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(2);
     });
 
@@ -184,7 +184,7 @@ describe('ManagementAPI: GetCorrelationsByProcessModelId', () => {
         .managementApiClient
         .getCorrelationsByProcessModelId(defaultIdentity, processModelId, 7, 5);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(3);
     });
 
@@ -194,7 +194,7 @@ describe('ManagementAPI: GetCorrelationsByProcessModelId', () => {
         .managementApiClient
         .getCorrelationsByProcessModelId(defaultIdentity, processModelId, 0, 20);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
+      should(correlationList.correlations).be.an.Array();
       should(correlationList.correlations).have.a.lengthOf(10);
 
     });
@@ -205,8 +205,8 @@ describe('ManagementAPI: GetCorrelationsByProcessModelId', () => {
         .managementApiClient
         .getCorrelationsByProcessModelId(defaultIdentity, processModelId, 1000);
 
-      should(correlationList.correlations).be.an.instanceOf(Array);
-      should(correlationList.correlations).have.a.lengthOf(0);
+      should(correlationList.correlations).be.an.Array();
+      should(correlationList.correlations).be.empty();
     });
   });
 

--- a/_integration_tests/test/correlations/get_process_instances_by_state.js
+++ b/_integration_tests/test/correlations/get_process_instances_by_state.js
@@ -105,7 +105,7 @@ describe('ManagementAPI: GetProcessInstancesByState', () => {
         .getProcessInstancesByState(superAdmin, CorrelationState.error);
 
       should(processInstanceList.processInstances).be.an.Array();
-      should(processInstanceList.processInstances).have.a.lengthOf(0);
+      should(processInstanceList.processInstances).be.empty();
     });
   });
 
@@ -130,7 +130,7 @@ describe('ManagementAPI: GetProcessInstancesByState', () => {
         .managementApiClient
         .getProcessInstancesByState(defaultIdentity, CorrelationState.finished, 5);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(5);
     });
 
@@ -140,7 +140,7 @@ describe('ManagementAPI: GetProcessInstancesByState', () => {
         .managementApiClient
         .getProcessInstancesByState(defaultIdentity, CorrelationState.finished, 0, 2);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(2);
     });
 
@@ -150,7 +150,7 @@ describe('ManagementAPI: GetProcessInstancesByState', () => {
         .managementApiClient
         .getProcessInstancesByState(defaultIdentity, CorrelationState.finished, 5, 2);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(2);
     });
 
@@ -160,7 +160,7 @@ describe('ManagementAPI: GetProcessInstancesByState', () => {
         .managementApiClient
         .getProcessInstancesByState(defaultIdentity, CorrelationState.finished, 7, 5);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(3);
     });
 
@@ -170,7 +170,7 @@ describe('ManagementAPI: GetProcessInstancesByState', () => {
         .managementApiClient
         .getProcessInstancesByState(defaultIdentity, CorrelationState.finished, 0, 20);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(10);
 
     });
@@ -181,8 +181,8 @@ describe('ManagementAPI: GetProcessInstancesByState', () => {
         .managementApiClient
         .getProcessInstancesByState(defaultIdentity, CorrelationState.finished, 1000);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
-      should(processInstanceList.processInstances).have.a.lengthOf(0);
+      should(processInstanceList.processInstances).be.an.Array();
+      should(processInstanceList.processInstances).be.empty();
     });
   });
 

--- a/_integration_tests/test/correlations/get_process_instances_for_correlation.js
+++ b/_integration_tests/test/correlations/get_process_instances_for_correlation.js
@@ -84,20 +84,13 @@ describe('ManagementAPI: GetProcessInstancesForCorrelation', () => {
       });
     });
 
-    it('should throw a NotFound error, if no ProcessInstances for the given CorrelationId exist', async () => {
+    it('should return an empty Array, if no ProcessInstances for the given CorrelationId exist', async () => {
+      const processInstanceList = await testFixtureProvider
+        .managementApiClient
+        .getProcessInstancesForCorrelation(superAdmin, 'some_non_existing_correlation');
 
-      try {
-        const processInstanceList = await testFixtureProvider
-          .managementApiClient
-          .getProcessInstancesForCorrelation(superAdmin, 'some_non_existing_correlation');
-
-          should.fail(processInstanceList, undefined, 'This request should have failed!');
-        } catch (error) {
-          const expectedErrorMessage = /no.*?found/i;
-          const expectedErrorCode = 404;
-          should(error.message).be.match(expectedErrorMessage);
-          should(error.code).be.equal(expectedErrorCode);
-      }
+      should(processInstanceList.processInstances).be.an.Array();
+      should(processInstanceList.processInstances).be.empty();
     });
   });
 
@@ -119,7 +112,7 @@ describe('ManagementAPI: GetProcessInstancesForCorrelation', () => {
         .managementApiClient
         .getProcessInstancesForCorrelation(defaultIdentity, correlationId, 5);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(5);
     });
 
@@ -129,7 +122,7 @@ describe('ManagementAPI: GetProcessInstancesForCorrelation', () => {
         .managementApiClient
         .getProcessInstancesForCorrelation(defaultIdentity, correlationId, 0, 2);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(2);
     });
 
@@ -139,7 +132,7 @@ describe('ManagementAPI: GetProcessInstancesForCorrelation', () => {
         .managementApiClient
         .getProcessInstancesForCorrelation(defaultIdentity, correlationId, 5, 2);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(2);
     });
 
@@ -149,7 +142,7 @@ describe('ManagementAPI: GetProcessInstancesForCorrelation', () => {
         .managementApiClient
         .getProcessInstancesForCorrelation(defaultIdentity, correlationId, 7, 5);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(3);
     });
 
@@ -159,7 +152,7 @@ describe('ManagementAPI: GetProcessInstancesForCorrelation', () => {
         .managementApiClient
         .getProcessInstancesForCorrelation(defaultIdentity, correlationId, 0, 20);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(10);
 
     });
@@ -170,8 +163,8 @@ describe('ManagementAPI: GetProcessInstancesForCorrelation', () => {
         .managementApiClient
         .getProcessInstancesForCorrelation(defaultIdentity, correlationId, 1000);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
-      should(processInstanceList.processInstances).have.a.lengthOf(0);
+      should(processInstanceList.processInstances).be.an.Array();
+      should(processInstanceList.processInstances).be.empty();
     });
   });
 

--- a/_integration_tests/test/correlations/get_process_instances_for_process_model.js
+++ b/_integration_tests/test/correlations/get_process_instances_for_process_model.js
@@ -89,20 +89,13 @@ describe('ManagementAPI: GetProcessInstancesForProcessModel', () => {
       });
     });
 
-    it('should throw a NotFound error, if no ProcessInstances for the given ProcessModelId exist', async () => {
+    it('should return an empty Array, if no ProcessInstances for the given ProcessModelId exist', async () => {
+      const processInstanceList = await testFixtureProvider
+        .managementApiClient
+        .getProcessInstancesForProcessModel(superAdmin, 'some_id_with_no_instances');
 
-      try {
-        const processInstanceList = await testFixtureProvider
-          .managementApiClient
-          .getProcessInstancesForProcessModel(superAdmin, 'some_id_with_no_instances');
-
-          should.fail(processInstanceList, undefined, 'This request should have failed!');
-        } catch (error) {
-          const expectedErrorMessage = /no.*?found/i;
-          const expectedErrorCode = 404;
-          should(error.message).be.match(expectedErrorMessage);
-          should(error.code).be.equal(expectedErrorCode);
-      }
+      should(processInstanceList.processInstances).be.an.Array();
+      should(processInstanceList.processInstances).be.empty();
     });
   });
 
@@ -124,7 +117,7 @@ describe('ManagementAPI: GetProcessInstancesForProcessModel', () => {
         .managementApiClient
         .getProcessInstancesForProcessModel(defaultIdentity, processModelId, 5);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(5);
     });
 
@@ -134,7 +127,7 @@ describe('ManagementAPI: GetProcessInstancesForProcessModel', () => {
         .managementApiClient
         .getProcessInstancesForProcessModel(defaultIdentity, processModelId, 0, 2);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(2);
     });
 
@@ -144,7 +137,7 @@ describe('ManagementAPI: GetProcessInstancesForProcessModel', () => {
         .managementApiClient
         .getProcessInstancesForProcessModel(defaultIdentity, processModelId, 5, 2);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(2);
     });
 
@@ -154,7 +147,7 @@ describe('ManagementAPI: GetProcessInstancesForProcessModel', () => {
         .managementApiClient
         .getProcessInstancesForProcessModel(defaultIdentity, processModelId, 7, 5);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(3);
     });
 
@@ -164,7 +157,7 @@ describe('ManagementAPI: GetProcessInstancesForProcessModel', () => {
         .managementApiClient
         .getProcessInstancesForProcessModel(defaultIdentity, processModelId, 0, 20);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
+      should(processInstanceList.processInstances).be.an.Array();
       should(processInstanceList.processInstances).have.a.lengthOf(10);
 
     });
@@ -175,8 +168,8 @@ describe('ManagementAPI: GetProcessInstancesForProcessModel', () => {
         .managementApiClient
         .getProcessInstancesForProcessModel(defaultIdentity, processModelId, 1000);
 
-      should(processInstanceList.processInstances).be.an.instanceOf(Array);
-      should(processInstanceList.processInstances).have.a.lengthOf(0);
+      should(processInstanceList.processInstances).be.an.Array();
+      should(processInstanceList.processInstances).be.empty();
     });
   });
 

--- a/_integration_tests/test/cronjobs/get_active_cronjobs.js
+++ b/_integration_tests/test/cronjobs/get_active_cronjobs.js
@@ -108,7 +108,7 @@ describe('ManagementAPI: GetAllActiveCronjobs', () => {
         .managementApiClient
         .getAllActiveCronjobs(defaultIdentity, 4);
 
-      should(cronjobList.cronjobs).be.an.instanceOf(Array);
+      should(cronjobList.cronjobs).be.an.Array();
       should(cronjobList.cronjobs).have.a.lengthOf(3);
     });
 
@@ -118,7 +118,7 @@ describe('ManagementAPI: GetAllActiveCronjobs', () => {
         .managementApiClient
         .getAllActiveCronjobs(defaultIdentity, 0, 2);
 
-      should(cronjobList.cronjobs).be.an.instanceOf(Array);
+      should(cronjobList.cronjobs).be.an.Array();
       should(cronjobList.cronjobs).have.a.lengthOf(2);
     });
 
@@ -128,7 +128,7 @@ describe('ManagementAPI: GetAllActiveCronjobs', () => {
         .managementApiClient
         .getAllActiveCronjobs(defaultIdentity, 3, 2);
 
-      should(cronjobList.cronjobs).be.an.instanceOf(Array);
+      should(cronjobList.cronjobs).be.an.Array();
       should(cronjobList.cronjobs).have.a.lengthOf(2);
     });
 
@@ -138,7 +138,7 @@ describe('ManagementAPI: GetAllActiveCronjobs', () => {
         .managementApiClient
         .getAllActiveCronjobs(defaultIdentity, 5, 5);
 
-      should(cronjobList.cronjobs).be.an.instanceOf(Array);
+      should(cronjobList.cronjobs).be.an.Array();
       should(cronjobList.cronjobs).have.a.lengthOf(2);
     });
 
@@ -148,7 +148,7 @@ describe('ManagementAPI: GetAllActiveCronjobs', () => {
         .managementApiClient
         .getAllActiveCronjobs(defaultIdentity, 0, 20);
 
-      should(cronjobList.cronjobs).be.an.instanceOf(Array);
+      should(cronjobList.cronjobs).be.an.Array();
       should(cronjobList.cronjobs).have.a.lengthOf(7);
 
     });
@@ -159,8 +159,8 @@ describe('ManagementAPI: GetAllActiveCronjobs', () => {
         .managementApiClient
         .getAllActiveCronjobs(defaultIdentity, 1000);
 
-      should(cronjobList.cronjobs).be.an.instanceOf(Array);
-      should(cronjobList.cronjobs).have.a.lengthOf(0);
+      should(cronjobList.cronjobs).be.an.Array();
+      should(cronjobList.cronjobs).be.empty();
     });
   });
 

--- a/_integration_tests/test/cronjobs/get_history_for_crontab.js
+++ b/_integration_tests/test/cronjobs/get_history_for_crontab.js
@@ -157,7 +157,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForCrontab', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForCrontab(defaultIdentity, crontab, 4);
 
-      should(cronjobHistory.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistory.cronjobHistories).be.an.Array();
       should(cronjobHistory.cronjobHistories).have.a.lengthOf(3);
     });
 
@@ -167,7 +167,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForCrontab', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForCrontab(defaultIdentity, crontab, 0, 2);
 
-      should(cronjobHistory.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistory.cronjobHistories).be.an.Array();
       should(cronjobHistory.cronjobHistories).have.a.lengthOf(2);
     });
 
@@ -177,7 +177,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForCrontab', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForCrontab(defaultIdentity, crontab, 3, 2);
 
-      should(cronjobHistory.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistory.cronjobHistories).be.an.Array();
       should(cronjobHistory.cronjobHistories).have.a.lengthOf(2);
     });
 
@@ -187,7 +187,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForCrontab', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForCrontab(defaultIdentity, crontab, 5, 5);
 
-      should(cronjobHistory.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistory.cronjobHistories).be.an.Array();
       should(cronjobHistory.cronjobHistories).have.a.lengthOf(2);
     });
 
@@ -197,7 +197,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForCrontab', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForCrontab(defaultIdentity, crontab, 0, 20);
 
-      should(cronjobHistory.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistory.cronjobHistories).be.an.Array();
       should(cronjobHistory.cronjobHistories).have.a.lengthOf(7);
 
     });
@@ -208,8 +208,8 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForCrontab', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForCrontab(defaultIdentity, crontab, 1000);
 
-      should(cronjobHistory.cronjobHistories).be.an.instanceOf(Array);
-      should(cronjobHistory.cronjobHistories).have.a.lengthOf(0);
+      should(cronjobHistory.cronjobHistories).be.an.Array();
+      should(cronjobHistory.cronjobHistories).be.empty();
     });
   });
 

--- a/_integration_tests/test/cronjobs/get_history_for_process_model.js
+++ b/_integration_tests/test/cronjobs/get_history_for_process_model.js
@@ -165,7 +165,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForProcessModel', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForProcessModel(defaultIdentity, processModelId, startEventId, 4);
 
-      should(cronjobHistoryList.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistoryList.cronjobHistories).be.an.Array();
       should(cronjobHistoryList.cronjobHistories).have.a.lengthOf(3);
     });
 
@@ -175,7 +175,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForProcessModel', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForProcessModel(defaultIdentity, processModelId, startEventId, 0, 2);
 
-      should(cronjobHistoryList.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistoryList.cronjobHistories).be.an.Array();
       should(cronjobHistoryList.cronjobHistories).have.a.lengthOf(2);
     });
 
@@ -185,7 +185,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForProcessModel', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForProcessModel(defaultIdentity, processModelId, startEventId, 3, 2);
 
-      should(cronjobHistoryList.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistoryList.cronjobHistories).be.an.Array();
       should(cronjobHistoryList.cronjobHistories).have.a.lengthOf(2);
     });
 
@@ -195,7 +195,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForProcessModel', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForProcessModel(defaultIdentity, processModelId, startEventId, 5, 5);
 
-      should(cronjobHistoryList.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistoryList.cronjobHistories).be.an.Array();
       should(cronjobHistoryList.cronjobHistories).have.a.lengthOf(2);
     });
 
@@ -205,7 +205,7 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForProcessModel', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForProcessModel(defaultIdentity, processModelId, startEventId, 0, 20);
 
-      should(cronjobHistoryList.cronjobHistories).be.an.instanceOf(Array);
+      should(cronjobHistoryList.cronjobHistories).be.an.Array();
       should(cronjobHistoryList.cronjobHistories).have.a.lengthOf(7);
 
     });
@@ -216,8 +216,8 @@ describe('ManagementAPI: GetCronjobExecutionHistoryForProcessModel', () => {
         .managementApiClient
         .getCronjobExecutionHistoryForProcessModel(defaultIdentity, processModelId, startEventId, 1000);
 
-      should(cronjobHistoryList.cronjobHistories).be.an.instanceOf(Array);
-      should(cronjobHistoryList.cronjobHistories).have.a.lengthOf(0);
+      should(cronjobHistoryList.cronjobHistories).be.an.Array();
+      should(cronjobHistoryList.cronjobHistories).be.empty();
     });
   });
 

--- a/_integration_tests/test/empty_activities/get_waiting_for_correlation.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_correlation.js
@@ -53,7 +53,7 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(1);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -80,7 +80,7 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities.length).be.greaterThan(0);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -115,8 +115,8 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
           .getEmptyActivitiesForCorrelation(defaultIdentity, processModelIdNoEmptyActivities);
 
         should(emptyActivityList).have.property('emptyActivities');
-        should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-        should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+        should(emptyActivityList.emptyActivities).be.an.Array();
+        should(emptyActivityList.emptyActivities).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -131,8 +131,8 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
         .getEmptyActivitiesForCorrelation(defaultIdentity, invalidCorrelationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -157,7 +157,7 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(5);
     });
 
@@ -169,7 +169,7 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -181,7 +181,7 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -193,7 +193,7 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(3);
     });
 
@@ -205,7 +205,7 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(10);
 
     });
@@ -218,8 +218,8 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -257,8 +257,8 @@ describe('ManagementAPI: GetEmptyActivitiesForCorrelation', () => {
         .getEmptyActivitiesForCorrelation(restrictedIdentity, correlationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_process_model.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_process_model.js
@@ -67,7 +67,7 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(1);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -97,8 +97,8 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
           .getEmptyActivitiesForProcessModel(defaultIdentity, processModelIdNoEmptyActivities);
 
         should(emptyActivityList).have.property('emptyActivities');
-        should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-        should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+        should(emptyActivityList.emptyActivities).be.an.Array();
+        should(emptyActivityList.emptyActivities).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -113,8 +113,8 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
         .getEmptyActivitiesForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -138,7 +138,7 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(5);
     });
 
@@ -150,7 +150,7 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -162,7 +162,7 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -174,7 +174,7 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(3);
     });
 
@@ -186,7 +186,7 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(10);
 
     });
@@ -199,8 +199,8 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -237,8 +237,8 @@ describe('ManagementAPI: GetEmptyActivitiesForProcessModel', () => {
         .getEmptyActivitiesForProcessModel(restrictedIdentity, processModelId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_process_model_in_correlation.js
@@ -48,7 +48,7 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(1);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -78,8 +78,8 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
           .getEmptyActivitiesForProcessModel(defaultIdentity, processModelIdNoEmptyActivities);
 
         should(emptyActivityList).have.property('emptyActivities');
-        should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-        should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+        should(emptyActivityList.emptyActivities).be.an.Array();
+        should(emptyActivityList.emptyActivities).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -94,8 +94,8 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
         .getEmptyActivitiesForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -107,8 +107,8 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
         .getEmptyActivitiesForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -133,7 +133,7 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(5);
     });
 
@@ -145,7 +145,7 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -157,7 +157,7 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -169,7 +169,7 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(3);
     });
 
@@ -181,7 +181,7 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(10);
 
     });
@@ -194,8 +194,8 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -232,8 +232,8 @@ describe(`ManagementAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => 
         .getEmptyActivitiesForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 });

--- a/_integration_tests/test/events/get_correlation_events.js
+++ b/_integration_tests/test/events/get_correlation_events.js
@@ -45,7 +45,7 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(1);
 
       eventList.events.forEach((event) => {
@@ -70,8 +70,8 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
 
     it('should return an empty Array, when the user has no access to any of the events', async () => {
@@ -86,8 +86,8 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
 
     });
   });
@@ -113,7 +113,7 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(5);
     });
 
@@ -125,7 +125,7 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -137,7 +137,7 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -149,7 +149,7 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(3);
     });
 
@@ -161,7 +161,7 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(10);
 
     });
@@ -174,8 +174,8 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -211,8 +211,8 @@ describe('ManagementAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 });

--- a/_integration_tests/test/events/get_correlation_process_model_events.js
+++ b/_integration_tests/test/events/get_correlation_process_model_events.js
@@ -45,7 +45,7 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events.length).be.greaterThan(0);
 
       eventList.events.forEach((event) => {
@@ -70,8 +70,8 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
 
     it('should return an empty Array, if the correlation_id does not exist', async () => {
@@ -84,8 +84,8 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -110,7 +110,7 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(5);
     });
 
@@ -122,7 +122,7 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -134,7 +134,7 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -146,7 +146,7 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(3);
     });
 
@@ -158,7 +158,7 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(10);
 
     });
@@ -171,8 +171,8 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -210,8 +210,8 @@ describe('ManagementAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 });

--- a/_integration_tests/test/events/get_process_model_events.js
+++ b/_integration_tests/test/events/get_process_model_events.js
@@ -56,7 +56,7 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events.length).be.greaterThan(0);
 
       eventList.events.forEach((event) => {
@@ -81,8 +81,8 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -106,7 +106,7 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(5);
     });
 
@@ -118,7 +118,7 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -130,7 +130,7 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -142,7 +142,7 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(3);
     });
 
@@ -154,7 +154,7 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(10);
 
     });
@@ -167,8 +167,8 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -201,8 +201,8 @@ describe('ManagementAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 });

--- a/_integration_tests/test/flow_node_instances/flow_node_instances.js
+++ b/_integration_tests/test/flow_node_instances/flow_node_instances.js
@@ -50,7 +50,7 @@ describe(`ManagementAPI: ${testCase}`, () => {
   }
 
   function assertFlowNodeInstances(flowNodeInstances) {
-    should(flowNodeInstances).be.an.instanceOf(Array);
+    should(flowNodeInstances).be.an.Array();
     should(flowNodeInstances.length).be.greaterThan(0);
 
     for (const flowNodeInstance of flowNodeInstances) {

--- a/_integration_tests/test/flow_node_instances/get_all_suspended.js
+++ b/_integration_tests/test/flow_node_instances/get_all_suspended.js
@@ -89,7 +89,7 @@ describe('ManagementAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(4);
     });
 
@@ -100,7 +100,7 @@ describe('ManagementAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -111,7 +111,7 @@ describe('ManagementAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -122,7 +122,7 @@ describe('ManagementAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(3);
     });
 
@@ -133,7 +133,7 @@ describe('ManagementAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(9);
     });
 
@@ -144,8 +144,8 @@ describe('ManagementAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -182,8 +182,8 @@ describe('ManagementAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(restrictedIdentity);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/flow_node_instances/get_waiting_for_correlation.js
+++ b/_integration_tests/test/flow_node_instances/get_waiting_for_correlation.js
@@ -115,7 +115,7 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
 
         should(taskList).have.property('tasks');
         should(taskList.tasks).be.instanceOf(Array);
-        should(taskList.tasks).have.a.lengthOf(0);
+        should(taskList.tasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -131,7 +131,7 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
 
       should(taskList).have.property('tasks');
       should(taskList.tasks).be.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -155,7 +155,7 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 4);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(5);
     });
 
@@ -166,7 +166,7 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -177,7 +177,7 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -188,7 +188,7 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(3);
     });
 
@@ -199,7 +199,7 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(9);
     });
 
@@ -210,8 +210,8 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -248,8 +248,8 @@ describe('ManagementAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(restrictedIdentity, correlationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/flow_node_instances/get_waiting_for_process_model.js
+++ b/_integration_tests/test/flow_node_instances/get_waiting_for_process_model.js
@@ -89,8 +89,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
           .getSuspendedTasksForProcessModel(defaultIdentity, processModelIdNoUserTasks);
 
         should(taskList).have.property('tasks');
-        should(taskList.tasks).be.an.instanceOf(Array);
-        should(taskList.tasks).have.a.lengthOf(0);
+        should(taskList.tasks).be.an.Array();
+        should(taskList.tasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -105,8 +105,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -129,7 +129,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 4);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(5);
     });
 
@@ -140,7 +140,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(2);
     });
 
@@ -151,7 +151,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(2);
     });
 
@@ -162,7 +162,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(3);
     });
 
@@ -173,7 +173,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(9);
 
     });
@@ -185,8 +185,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -216,8 +216,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(restrictedIdentity, processModelId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/flow_node_instances/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/flow_node_instances/get_waiting_for_process_model_in_correlation.js
@@ -76,8 +76,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
           .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelIdNoTasks, correlationId);
 
         should(taskList).have.property('tasks');
-        should(taskList.tasks).be.an.instanceOf(Array);
-        should(taskList.tasks).have.a.lengthOf(0);
+        should(taskList.tasks).be.an.Array();
+        should(taskList.tasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -92,8 +92,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -105,8 +105,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -130,7 +130,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 4);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(5);
     });
 
@@ -141,7 +141,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -152,7 +152,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -163,7 +163,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(3);
     });
 
@@ -174,7 +174,7 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(9);
     });
 
@@ -185,8 +185,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -223,8 +223,8 @@ describe('ManagementAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/kpi/get_active_tokens_for_correlation_and_process_model.js
+++ b/_integration_tests/test/kpi/get_active_tokens_for_correlation_and_process_model.js
@@ -97,7 +97,7 @@ describe('ManagementAPI: GetActiveTokensForCorrelationAndProcessModel', () => {
         .managementApiClient
         .getActiveTokensForCorrelationAndProcessModel(defaultIdentity, correlationId, processModelId, 5);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(5);
     });
 
@@ -107,7 +107,7 @@ describe('ManagementAPI: GetActiveTokensForCorrelationAndProcessModel', () => {
         .managementApiClient
         .getActiveTokensForCorrelationAndProcessModel(defaultIdentity, correlationId, processModelId, 0, 2);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -117,7 +117,7 @@ describe('ManagementAPI: GetActiveTokensForCorrelationAndProcessModel', () => {
         .managementApiClient
         .getActiveTokensForCorrelationAndProcessModel(defaultIdentity, correlationId, processModelId, 5, 2);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -127,7 +127,7 @@ describe('ManagementAPI: GetActiveTokensForCorrelationAndProcessModel', () => {
         .managementApiClient
         .getActiveTokensForCorrelationAndProcessModel(defaultIdentity, correlationId, processModelId, 7, 5);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(3);
     });
 
@@ -137,7 +137,7 @@ describe('ManagementAPI: GetActiveTokensForCorrelationAndProcessModel', () => {
         .managementApiClient
         .getActiveTokensForCorrelationAndProcessModel(defaultIdentity, correlationId, processModelId, 0, 20);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(10);
 
     });
@@ -148,8 +148,8 @@ describe('ManagementAPI: GetActiveTokensForCorrelationAndProcessModel', () => {
         .managementApiClient
         .getActiveTokensForCorrelationAndProcessModel(defaultIdentity, correlationId, processModelId, 1000);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
-      should(activeTokenList.activeTokens).have.a.lengthOf(0);
+      should(activeTokenList.activeTokens).be.an.Array();
+      should(activeTokenList.activeTokens).be.empty();
     });
   });
 

--- a/_integration_tests/test/kpi/get_active_tokens_for_flow_node.js
+++ b/_integration_tests/test/kpi/get_active_tokens_for_flow_node.js
@@ -147,7 +147,7 @@ describe('ManagementAPI: GetActiveTokensForFlowNode', () => {
         .managementApiClient
         .getActiveTokensForFlowNode(defaultIdentity, userTask1Id, 2);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(3);
     });
 
@@ -157,7 +157,7 @@ describe('ManagementAPI: GetActiveTokensForFlowNode', () => {
         .managementApiClient
         .getActiveTokensForFlowNode(defaultIdentity, userTask1Id, 0, 2);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -167,7 +167,7 @@ describe('ManagementAPI: GetActiveTokensForFlowNode', () => {
         .managementApiClient
         .getActiveTokensForFlowNode(defaultIdentity, userTask1Id, 2, 2);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -177,7 +177,7 @@ describe('ManagementAPI: GetActiveTokensForFlowNode', () => {
         .managementApiClient
         .getActiveTokensForFlowNode(defaultIdentity, userTask1Id, 2, 5);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(3);
     });
 
@@ -187,7 +187,7 @@ describe('ManagementAPI: GetActiveTokensForFlowNode', () => {
         .managementApiClient
         .getActiveTokensForFlowNode(defaultIdentity, userTask1Id, 0, 20);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(5);
 
     });
@@ -198,8 +198,8 @@ describe('ManagementAPI: GetActiveTokensForFlowNode', () => {
         .managementApiClient
         .getActiveTokensForFlowNode(defaultIdentity, userTask1Id, 1000);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
-      should(activeTokenList.activeTokens).have.a.lengthOf(0);
+      should(activeTokenList.activeTokens).be.an.Array();
+      should(activeTokenList.activeTokens).be.empty();
     });
   });
 

--- a/_integration_tests/test/kpi/get_active_tokens_for_process_instance.js
+++ b/_integration_tests/test/kpi/get_active_tokens_for_process_instance.js
@@ -98,7 +98,7 @@ describe('ManagementAPI: GetActiveTokensForProcessInstance', () => {
         .managementApiClient
         .getActiveTokensForProcessInstance(defaultIdentity, processInstanceId, 1);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(3);
     });
 
@@ -108,7 +108,7 @@ describe('ManagementAPI: GetActiveTokensForProcessInstance', () => {
         .managementApiClient
         .getActiveTokensForProcessInstance(defaultIdentity, processInstanceId, 0, 2);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -118,7 +118,7 @@ describe('ManagementAPI: GetActiveTokensForProcessInstance', () => {
         .managementApiClient
         .getActiveTokensForProcessInstance(defaultIdentity, processInstanceId, 1, 2);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -128,7 +128,7 @@ describe('ManagementAPI: GetActiveTokensForProcessInstance', () => {
         .managementApiClient
         .getActiveTokensForProcessInstance(defaultIdentity, processInstanceId, 2, 5);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -138,7 +138,7 @@ describe('ManagementAPI: GetActiveTokensForProcessInstance', () => {
         .managementApiClient
         .getActiveTokensForProcessInstance(defaultIdentity, processInstanceId, 0, 20);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokenList.activeTokens).be.an.Array();
       should(activeTokenList.activeTokens).have.a.lengthOf(4);
 
     });
@@ -149,8 +149,8 @@ describe('ManagementAPI: GetActiveTokensForProcessInstance', () => {
         .managementApiClient
         .getActiveTokensForProcessInstance(defaultIdentity, processInstanceId, 1000);
 
-      should(activeTokenList.activeTokens).be.an.instanceOf(Array);
-      should(activeTokenList.activeTokens).have.a.lengthOf(0);
+      should(activeTokenList.activeTokens).be.an.Array();
+      should(activeTokenList.activeTokens).be.empty();
     });
   });
 

--- a/_integration_tests/test/kpi/get_active_tokens_for_process_model.js
+++ b/_integration_tests/test/kpi/get_active_tokens_for_process_model.js
@@ -125,7 +125,7 @@ describe('ManagementAPI: GetActiveTokensForProcessModel', () => {
         .managementApiClient
         .getActiveTokensForProcessModel(defaultIdentity, processModelIdTokenSample, 1);
 
-      should(activeTokensList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokensList.activeTokens).be.an.Array();
       should(activeTokensList.activeTokens).have.a.lengthOf(3);
     });
 
@@ -135,7 +135,7 @@ describe('ManagementAPI: GetActiveTokensForProcessModel', () => {
         .managementApiClient
         .getActiveTokensForProcessModel(defaultIdentity, processModelIdTokenSample, 0, 2);
 
-      should(activeTokensList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokensList.activeTokens).be.an.Array();
       should(activeTokensList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -145,7 +145,7 @@ describe('ManagementAPI: GetActiveTokensForProcessModel', () => {
         .managementApiClient
         .getActiveTokensForProcessModel(defaultIdentity, processModelIdTokenSample, 1, 2);
 
-      should(activeTokensList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokensList.activeTokens).be.an.Array();
       should(activeTokensList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -155,7 +155,7 @@ describe('ManagementAPI: GetActiveTokensForProcessModel', () => {
         .managementApiClient
         .getActiveTokensForProcessModel(defaultIdentity, processModelIdTokenSample, 2, 5);
 
-      should(activeTokensList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokensList.activeTokens).be.an.Array();
       should(activeTokensList.activeTokens).have.a.lengthOf(2);
     });
 
@@ -165,7 +165,7 @@ describe('ManagementAPI: GetActiveTokensForProcessModel', () => {
         .managementApiClient
         .getActiveTokensForProcessModel(defaultIdentity, processModelIdTokenSample, 0, 20);
 
-      should(activeTokensList.activeTokens).be.an.instanceOf(Array);
+      should(activeTokensList.activeTokens).be.an.Array();
       should(activeTokensList.activeTokens).have.a.lengthOf(4);
 
     });
@@ -176,8 +176,8 @@ describe('ManagementAPI: GetActiveTokensForProcessModel', () => {
         .managementApiClient
         .getActiveTokensForProcessModel(defaultIdentity, processModelIdTokenSample, 1000);
 
-      should(activeTokensList.activeTokens).be.an.instanceOf(Array);
-      should(activeTokensList.activeTokens).have.a.lengthOf(0);
+      should(activeTokensList.activeTokens).be.an.Array();
+      should(activeTokensList.activeTokens).be.empty();
     });
   });
 

--- a/_integration_tests/test/kpi/get_runtime_informations_for_process_model.js
+++ b/_integration_tests/test/kpi/get_runtime_informations_for_process_model.js
@@ -71,7 +71,7 @@ describe('ManagementAPI: GetRuntimeInformationForProcessModel ', () => {
         .managementApiClient
         .getRuntimeInformationForProcessModel(defaultIdentity, processModelId, 5);
 
-      should(runtimeInfos.flowNodeRuntimeInformation).be.an.instanceOf(Array);
+      should(runtimeInfos.flowNodeRuntimeInformation).be.an.Array();
       should(runtimeInfos.flowNodeRuntimeInformation).have.a.lengthOf(5);
     });
 
@@ -81,7 +81,7 @@ describe('ManagementAPI: GetRuntimeInformationForProcessModel ', () => {
         .managementApiClient
         .getRuntimeInformationForProcessModel(defaultIdentity, processModelId, 0, 2);
 
-      should(runtimeInfos.flowNodeRuntimeInformation).be.an.instanceOf(Array);
+      should(runtimeInfos.flowNodeRuntimeInformation).be.an.Array();
       should(runtimeInfos.flowNodeRuntimeInformation).have.a.lengthOf(2);
     });
 
@@ -91,7 +91,7 @@ describe('ManagementAPI: GetRuntimeInformationForProcessModel ', () => {
         .managementApiClient
         .getRuntimeInformationForProcessModel(defaultIdentity, processModelId, 5, 2);
 
-      should(runtimeInfos.flowNodeRuntimeInformation).be.an.instanceOf(Array);
+      should(runtimeInfos.flowNodeRuntimeInformation).be.an.Array();
       should(runtimeInfos.flowNodeRuntimeInformation).have.a.lengthOf(2);
     });
 
@@ -101,7 +101,7 @@ describe('ManagementAPI: GetRuntimeInformationForProcessModel ', () => {
         .managementApiClient
         .getRuntimeInformationForProcessModel(defaultIdentity, processModelId, 7, 5);
 
-      should(runtimeInfos.flowNodeRuntimeInformation).be.an.instanceOf(Array);
+      should(runtimeInfos.flowNodeRuntimeInformation).be.an.Array();
       should(runtimeInfos.flowNodeRuntimeInformation).have.a.lengthOf(3);
     });
 
@@ -111,7 +111,7 @@ describe('ManagementAPI: GetRuntimeInformationForProcessModel ', () => {
         .managementApiClient
         .getRuntimeInformationForProcessModel(defaultIdentity, processModelId, 0, 20);
 
-      should(runtimeInfos.flowNodeRuntimeInformation).be.an.instanceOf(Array);
+      should(runtimeInfos.flowNodeRuntimeInformation).be.an.Array();
       should(runtimeInfos.flowNodeRuntimeInformation).have.a.lengthOf(10);
 
     });
@@ -122,8 +122,8 @@ describe('ManagementAPI: GetRuntimeInformationForProcessModel ', () => {
         .managementApiClient
         .getRuntimeInformationForProcessModel(defaultIdentity, processModelId, 1000);
 
-      should(runtimeInfos.flowNodeRuntimeInformation).be.an.instanceOf(Array);
-      should(runtimeInfos.flowNodeRuntimeInformation).have.a.lengthOf(0);
+      should(runtimeInfos.flowNodeRuntimeInformation).be.an.Array();
+      should(runtimeInfos.flowNodeRuntimeInformation).be.empty();
     });
   });
 

--- a/_integration_tests/test/log_history/get_process_instance_logs.js
+++ b/_integration_tests/test/log_history/get_process_instance_logs.js
@@ -78,7 +78,7 @@ describe('ManagementAPI: GetProcessInstanceLogs', () => {
         .managementApiClient
         .getProcessInstanceLog(defaultIdentity, processModelId, processInstanceId, 5);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(9);
     });
 
@@ -88,7 +88,7 @@ describe('ManagementAPI: GetProcessInstanceLogs', () => {
         .managementApiClient
         .getProcessInstanceLog(defaultIdentity, processModelId, processInstanceId, 0, 2);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(2);
     });
 
@@ -98,7 +98,7 @@ describe('ManagementAPI: GetProcessInstanceLogs', () => {
         .managementApiClient
         .getProcessInstanceLog(defaultIdentity, processModelId, processInstanceId, 5, 2);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(2);
     });
 
@@ -108,7 +108,7 @@ describe('ManagementAPI: GetProcessInstanceLogs', () => {
         .managementApiClient
         .getProcessInstanceLog(defaultIdentity, processModelId, processInstanceId, 11, 5);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(3);
     });
 
@@ -118,7 +118,7 @@ describe('ManagementAPI: GetProcessInstanceLogs', () => {
         .managementApiClient
         .getProcessInstanceLog(defaultIdentity, processModelId, processInstanceId, 0, 20);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(14);
 
     });
@@ -129,8 +129,8 @@ describe('ManagementAPI: GetProcessInstanceLogs', () => {
         .managementApiClient
         .getProcessInstanceLog(defaultIdentity, processModelId, processInstanceId, 1000);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
-      should(logEntryList.logEntries).have.a.lengthOf(0);
+      should(logEntryList.logEntries).be.an.Array();
+      should(logEntryList.logEntries).be.empty();
     });
   });
 

--- a/_integration_tests/test/log_history/get_process_model_logs.js
+++ b/_integration_tests/test/log_history/get_process_model_logs.js
@@ -102,7 +102,7 @@ describe('ManagementAPI: GetProcessModelLgos', () => {
         .managementApiClient
         .getProcessModelLog(defaultIdentity, processModelId, correlationId, 5);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(9);
     });
 
@@ -112,7 +112,7 @@ describe('ManagementAPI: GetProcessModelLgos', () => {
         .managementApiClient
         .getProcessModelLog(defaultIdentity, processModelId, correlationId, 0, 2);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(2);
     });
 
@@ -122,7 +122,7 @@ describe('ManagementAPI: GetProcessModelLgos', () => {
         .managementApiClient
         .getProcessModelLog(defaultIdentity, processModelId, correlationId, 5, 2);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(2);
     });
 
@@ -132,7 +132,7 @@ describe('ManagementAPI: GetProcessModelLgos', () => {
         .managementApiClient
         .getProcessModelLog(defaultIdentity, processModelId, correlationId, 11, 5);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(3);
     });
 
@@ -142,7 +142,7 @@ describe('ManagementAPI: GetProcessModelLgos', () => {
         .managementApiClient
         .getProcessModelLog(defaultIdentity, processModelId, correlationId, 0, 20);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
+      should(logEntryList.logEntries).be.an.Array();
       should(logEntryList.logEntries).have.a.lengthOf(14);
 
     });
@@ -153,8 +153,8 @@ describe('ManagementAPI: GetProcessModelLgos', () => {
         .managementApiClient
         .getProcessModelLog(defaultIdentity, processModelId, correlationId, 1000);
 
-      should(logEntryList.logEntries).be.an.instanceOf(Array);
-      should(logEntryList.logEntries).have.a.lengthOf(0);
+      should(logEntryList.logEntries).be.an.Array();
+      should(logEntryList.logEntries).be.empty();
     });
   });
 

--- a/_integration_tests/test/manual_tasks/get_waiting_for_correlation.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_correlation.js
@@ -53,7 +53,7 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -80,7 +80,7 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -116,8 +116,8 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
           .getManualTasksForCorrelation(defaultIdentity, processModelIdNoManualTasks);
 
         should(manualTaskList).have.property('manualTasks');
-        should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-        should(manualTaskList.manualTasks).have.a.lengthOf(0);
+        should(manualTaskList.manualTasks).be.an.Array();
+        should(manualTaskList.manualTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -132,8 +132,8 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
         .getManualTasksForCorrelation(defaultIdentity, invalidCorrelationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -158,7 +158,7 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(5);
     });
 
@@ -170,7 +170,7 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -182,7 +182,7 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -194,7 +194,7 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(3);
     });
 
@@ -206,7 +206,7 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(10);
 
     });
@@ -219,8 +219,8 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -257,8 +257,8 @@ describe('ManagementAPI: GetManualTasksForCorrelation', () => {
         .getManualTasksForCorrelation(restrictedIdentity, correlationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_process_model.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_process_model.js
@@ -67,7 +67,7 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -97,8 +97,8 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
           .getManualTasksForProcessModel(defaultIdentity, processModelIdNoManualTasks);
 
         should(manualTaskList).have.property('manualTasks');
-        should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-        should(manualTaskList.manualTasks).have.a.lengthOf(0);
+        should(manualTaskList.manualTasks).be.an.Array();
+        should(manualTaskList.manualTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -113,8 +113,8 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
         .getManualTasksForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -138,7 +138,7 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(5);
     });
 
@@ -150,7 +150,7 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -162,7 +162,7 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -174,7 +174,7 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(3);
     });
 
@@ -186,7 +186,7 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(10);
 
     });
@@ -199,8 +199,8 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -230,8 +230,8 @@ describe('ManagementAPI: GetManualTasksForProcessModel', () => {
         .getManualTasksForProcessModel(restrictedIdentity, processModelId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_process_model_in_correlation.js
@@ -48,7 +48,7 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -78,8 +78,8 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
           .getManualTasksForProcessModel(defaultIdentity, processModelIdNoManualTasks);
 
         should(manualTaskList).have.property('manualTasks');
-        should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-        should(manualTaskList.manualTasks).have.a.lengthOf(0);
+        should(manualTaskList.manualTasks).be.an.Array();
+        should(manualTaskList.manualTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -94,8 +94,8 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
         .getManualTasksForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -107,8 +107,8 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
         .getManualTasksForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -133,7 +133,7 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(5);
     });
 
@@ -145,7 +145,7 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -157,7 +157,7 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -169,7 +169,7 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(3);
     });
 
@@ -181,7 +181,7 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(10);
 
     });
@@ -194,8 +194,8 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -232,8 +232,8 @@ describe(`ManagementAPI: GetManualTasksForProcessModelInCorrelation`, () => {
         .getManualTasksForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/process_models/get_process_model_start_events.js
+++ b/_integration_tests/test/process_models/get_process_model_start_events.js
@@ -29,7 +29,7 @@ describe('ManagementAPI:   GET  ->  /process_models/:process_model_id/events', (
       .getStartEventsForProcessModel(testFixtureProvider.identities.defaultUser, processModelId);
 
     should(processModel).have.property('events');
-    should(processModel.events).be.an.instanceOf(Array);
+    should(processModel.events).be.an.Array();
     should(processModel.events.length).be.greaterThan(0);
 
     for (const event of processModel.events) {
@@ -44,7 +44,7 @@ describe('ManagementAPI:   GET  ->  /process_models/:process_model_id/events', (
       .getStartEventsForProcessModel(testFixtureProvider.identities.superAdmin, processModelId);
 
     should(processModel).have.property('events');
-    should(processModel.events).be.an.instanceOf(Array);
+    should(processModel.events).be.an.Array();
     should(processModel.events.length).be.greaterThan(0);
 
     for (const event of processModel.events) {

--- a/_integration_tests/test/process_models/get_process_models.js
+++ b/_integration_tests/test/process_models/get_process_models.js
@@ -42,15 +42,15 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels.length).be.greaterThan(0);
 
       processModelList.processModels.forEach((processModel) => {
         should(processModel).have.property('id');
         should(processModel).have.property('startEvents');
         should(processModel).have.property('endEvents');
-        should(processModel.startEvents).be.an.instanceOf(Array);
-        should(processModel.endEvents).be.an.instanceOf(Array);
+        should(processModel.startEvents).be.an.Array();
+        should(processModel.endEvents).be.an.Array();
       });
     });
 
@@ -64,15 +64,15 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
 
       processModelList.processModels.forEach((processModel) => {
         should(processModel).have.property('id');
         should(processModel.id).not.be.equal('test_management_api_process_start');
         should(processModel).have.property('startEvents');
         should(processModel).have.property('endEvents');
-        should(processModel.startEvents).be.an.instanceOf(Array);
-        should(processModel.endEvents).be.an.instanceOf(Array);
+        should(processModel.startEvents).be.an.Array();
+        should(processModel.endEvents).be.an.Array();
       });
     });
 
@@ -84,18 +84,18 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
 
       processModelList.processModels.forEach((processModel) => {
         should(processModel).have.property('id');
         should(processModel).have.property('startEvents');
         should(processModel).have.property('endEvents');
-        should(processModel.startEvents).be.an.instanceOf(Array);
-        should(processModel.endEvents).be.an.instanceOf(Array);
+        should(processModel.startEvents).be.an.Array();
+        should(processModel.endEvents).be.an.Array();
 
         if (processModel.id === 'test_management_api_non_executable_process') {
-          should(processModel.startEvents).have.a.lengthOf(0);
-          should(processModel.endEvents).have.a.lengthOf(0);
+          should(processModel.startEvents).be.empty();
+          should(processModel.endEvents).be.empty();
         }
       });
     });
@@ -128,7 +128,7 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(5);
     });
 
@@ -140,7 +140,7 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(2);
     });
 
@@ -152,7 +152,7 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(2);
     });
 
@@ -164,7 +164,7 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(3);
     });
 
@@ -176,7 +176,7 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(10);
 
     });
@@ -189,8 +189,8 @@ describe('ManagementAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
-      should(processModelList.processModels).have.a.lengthOf(0);
+      should(processModelList.processModels).be.an.Array();
+      should(processModelList.processModels).be.empty();
     });
   });
 

--- a/_integration_tests/test/token_history/get_tokens_for_correlation_and_process_model.js
+++ b/_integration_tests/test/token_history/get_tokens_for_correlation_and_process_model.js
@@ -85,7 +85,7 @@ describe('ManagementAPI: GetTokensForCorrelationAndProcessModel', () => {
       .getTokensForCorrelationAndProcessModel(defaultIdentity, 'invalid_correlation_id', processModelId);
 
     should(tokenHistories).be.an.Object();
-    should(Object.keys(tokenHistories)).have.a.lengthOf(0);
+    should(Object.keys(tokenHistories)).be.empty();
   });
 
   it('should return an empty result set, if the ProcessModel does not exist', async () => {
@@ -94,7 +94,7 @@ describe('ManagementAPI: GetTokensForCorrelationAndProcessModel', () => {
       .getTokensForCorrelationAndProcessModel(defaultIdentity, correlationId, 'invalid_process_model');
 
     should(tokenHistories).be.an.Object();
-    should(Object.keys(tokenHistories)).have.a.lengthOf(0);
+    should(Object.keys(tokenHistories)).be.empty();
   });
 
   it('should fail to retrieve the token history, when the user is unauthorized', async () => {

--- a/_integration_tests/test/token_history/get_tokens_for_flow_node_by_process_instance.js
+++ b/_integration_tests/test/token_history/get_tokens_for_flow_node_by_process_instance.js
@@ -79,7 +79,7 @@ describe('ManagementAPI: getTokensForFlowNodeByProcessInstanceId', () => {
       .getTokensForFlowNodeByProcessInstanceId(defaultIdentity, 'invalid_process_instance_id', startEventId);
 
     should(tokenHistories).be.an.Object();
-    should(Object.keys(tokenHistories)).have.a.lengthOf(0);
+    should(Object.keys(tokenHistories)).be.empty();
   });
 
   it('should return an empty result set, if the FlowNode does not exist', async () => {
@@ -88,7 +88,7 @@ describe('ManagementAPI: getTokensForFlowNodeByProcessInstanceId', () => {
       .getTokensForFlowNodeByProcessInstanceId(defaultIdentity, processInstanceId, 'invalid_flow_node_id');
 
     should(tokenHistories).be.an.Object();
-    should(Object.keys(tokenHistories)).have.a.lengthOf(0);
+    should(Object.keys(tokenHistories)).be.empty();
   });
 
   it('should fail to retrieve the token history, when the user is unauthorized', async () => {

--- a/_integration_tests/test/token_history/get_tokens_for_process_instance.js
+++ b/_integration_tests/test/token_history/get_tokens_for_process_instance.js
@@ -90,7 +90,7 @@ describe('ManagementAPI: GetTokensForProcessInstance', () => {
       .getTokensForProcessInstance(defaultIdentity, 'invalid_process_instance_id');
 
     should(tokenHistories).be.an.Object();
-    should(Object.keys(tokenHistories)).have.a.lengthOf(0);
+    should(Object.keys(tokenHistories)).be.empty();
   });
 
   it('should fail to retrieve the token history, when the user is unauthorized', async () => {

--- a/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
@@ -53,7 +53,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -69,7 +69,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
       should(userTask).not.have.property('identity');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -92,7 +92,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -103,7 +103,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
       should(userTask).have.property('data');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -137,8 +137,8 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
 
         should(userTaskList).have.property('userTasks');
-        should(userTaskList.userTasks).be.an.instanceOf(Array);
-        should(userTaskList.userTasks).have.a.lengthOf(0);
+        should(userTaskList.userTasks).be.an.Array();
+        should(userTaskList.userTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -153,8 +153,8 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
         .getUserTasksForCorrelation(defaultIdentity, invalidCorrelationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -179,7 +179,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(5);
     });
 
@@ -191,7 +191,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -203,7 +203,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -215,7 +215,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(3);
     });
 
@@ -227,7 +227,7 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(10);
 
     });
@@ -240,8 +240,8 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -278,8 +278,8 @@ describe('ManagementAPI: GetUserTasksForCorrelation', () => {
         .getUserTasksForCorrelation(restrictedIdentity, correlationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_process_model.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_process_model.js
@@ -67,7 +67,7 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -83,7 +83,7 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
       should(userTask).not.have.property('identity');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -114,8 +114,8 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
           .getUserTasksForProcessModel(defaultIdentity, processModelIdNoUserTasks);
 
         should(userTaskList).have.property('userTasks');
-        should(userTaskList.userTasks).be.an.instanceOf(Array);
-        should(userTaskList.userTasks).have.a.lengthOf(0);
+        should(userTaskList.userTasks).be.an.Array();
+        should(userTaskList.userTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -130,8 +130,8 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
         .getUserTasksForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -155,7 +155,7 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(5);
     });
 
@@ -167,7 +167,7 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -179,7 +179,7 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -191,7 +191,7 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(3);
     });
 
@@ -203,7 +203,7 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(10);
 
     });
@@ -216,8 +216,8 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -254,8 +254,8 @@ describe('ManagementAPI: GetUserTasksForProcessModel', () => {
         .getUserTasksForProcessModel(restrictedIdentity, processModelId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_process_model_in_correlation.js
@@ -48,7 +48,7 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -64,7 +64,7 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
       should(userTask).not.have.property('identity');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -90,8 +90,8 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
           .getUserTasksForProcessModelInCorrelation(defaultIdentity, processModelIdNoUserTasks, correlationId);
 
         should(userTaskList).have.property('userTasks');
-        should(userTaskList.userTasks).be.an.instanceOf(Array);
-        should(userTaskList.userTasks).have.a.lengthOf(0);
+        should(userTaskList.userTasks).be.an.Array();
+        should(userTaskList.userTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -106,8 +106,8 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
         .getUserTasksForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -119,8 +119,8 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
         .getUserTasksForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -145,7 +145,7 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(5);
     });
 
@@ -157,7 +157,7 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -169,7 +169,7 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -181,7 +181,7 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(3);
     });
 
@@ -193,7 +193,7 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(10);
 
     });
@@ -206,8 +206,8 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -244,8 +244,8 @@ describe(`ManagementAPI: GetUserTasksForProcessModelInCorrelation`, () => {
         .getUserTasksForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 });


### PR DESCRIPTION
## Changes

1. Refactor tests for Process Instance queries to expect an empty array instead of 404 errors, if no Process Instances were found
2. Improve usage of `should` assertions

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/550

PR: #74

## How to test the changes

Run the tests